### PR TITLE
Add queries for places/constituencies

### DIFF
--- a/Parliament.Data.Api.FixedQuery/Controllers/FixedQuery.Constituencies.cs
+++ b/Parliament.Data.Api.FixedQuery/Controllers/FixedQuery.Constituencies.cs
@@ -689,6 +689,44 @@ WHERE {
             return BaseController.ExecuteList(query);
         }
 
+        [HttpGet]
+        public Graph find_your_constituency()
+        {
+            var queryString = @"
+            PREFIX spatial: <http://data.ordnancesurvey.co.uk/ontology/spatialrelations/>
+            PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+            PREFIX admingeo: <http://data.ordnancesurvey.co.uk/ontology/admingeo/>
+            PREFIX : <http://id.ukpds.org/schema/>
+            CONSTRUCT {
+              ?region skos:prefLabel ?name  .
+              ?region a admingeo:EuropeanRegion .
+              ?region admingeo:gssCode ?gssCode .
+              ?region :count ?count .
+            }
+            WHERE {
+              {
+                SELECT ?region (COUNT(?westminsterConstituency) AS ?count) WHERE
+                {
+                    ?region a admingeo:EuropeanRegion .
+                    ?region admingeo:gssCode ?gssCode .
+                    ?region admingeo:westminsterConstituency ?westminsterConstituency .
+                } GROUP BY ?region
+              }
+              UNION
+              {
+                SELECT * WHERE {
+                    ?region skos:prefLabel ?name  .
+                    ?region a admingeo:EuropeanRegion .
+                    ?region admingeo:gssCode ?gssCode .
+                }
+              }
+            }
+            ";
+
+            var query = new SparqlParameterizedString(queryString);
+            return BaseController.ExecuteList(query);
+        }
+
         // TODO: Why is this singular? - still not completely solved here
         //[Route(@"{id:regex(^\w{8}$)}/contact_point", Name = "ConstituencyContactPoint")]
         [HttpGet]
@@ -768,12 +806,12 @@ WHERE {
 PREFIX geo: <http://www.w3.org/2003/01/geo/wgs84_pos#>
 
 CONSTRUCT {
-    ?postcode 
+    ?postcode
         geo:long ?long ;
         geo:lat ?lat .
-} 
+}
 WHERE {
-    BIND(@postcode as ?postcode) 
+    BIND(@postcode as ?postcode)
     ?postcode geo:long ?long ;
         geo:lat ?lat .
 }
@@ -783,7 +821,7 @@ PREFIX parl: <http://id.ukpds.org/schema/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
 construct {
-    ?constituencyGroup 
+    ?constituencyGroup
         a parl:ConstituencyGroup ;
         parl:constituencyGroupName ?constituencyGroupName ;
         parl:constituencyGroupHasHouseSeat ?houseSeat .
@@ -815,7 +853,7 @@ where {
     ?constituencyArea a parl:ConstituencyArea;
         parl:constituencyAreaExtent ?constituencyAreaExtent;
         parl:constituencyAreaHasConstituencyGroup ?constituencyGroup.
-    ?constituencyGroup parl:constituencyGroupName ?constituencyGroupName.    
+    ?constituencyGroup parl:constituencyGroupName ?constituencyGroupName.
     bind(strdt(concat(""Point("",@longitude,"" "",@latitude,"")""),geo:wktLiteral) as ?point)
     filter(geof:sfWithin(?point,?constituencyAreaExtent))
 
@@ -829,7 +867,7 @@ where {
         optional { ?member parl:personGivenName ?givenName . }
         optional { ?member parl:personFamilyName ?familyName . }
         optional { ?member <http://example.com/F31CBD81AD8343898B49DC65743F0BDF> ?displayAs } .
-        
+
         optional {
             ?member parl:partyMemberHasPartyMembership ?partyMembership .
             filter not exists { ?partyMembership a parl:PastPartyMembership . }

--- a/Parliament.Data.Api.FixedQuery/Controllers/FixedQuery.Regions.cs
+++ b/Parliament.Data.Api.FixedQuery/Controllers/FixedQuery.Regions.cs
@@ -1,84 +1,322 @@
-﻿namespace Parliament.Data.Api.FixedQuery.Controllers
+namespace Parliament.Data.Api.FixedQuery.Controllers
 {
-    using System;
-    using System.Linq;
-    using System.Web.Http;
-    using VDS.RDF;
-    using VDS.RDF.Query;
+  using System;
+  using System.Linq;
+  using System.Web.Http;
+  using VDS.RDF;
+  using VDS.RDF.Query;
 
-    public partial class FixedQueryController
+  public partial class FixedQueryController
+  {
+    [HttpGet]
+    public Graph region_index()
     {
-        [HttpGet]
-        public Graph region_index()
-        {
-            var externalQueryString = @"
-PREFIX spatial: <http://data.ordnancesurvey.co.uk/ontology/spatialrelations/>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX admingeo: <http://data.ordnancesurvey.co.uk/ontology/admingeo/>
-PREFIX : <http://id.ukpds.org/schema/>
+      var externalQueryString = @"
+      PREFIX spatial: <http://data.ordnancesurvey.co.uk/ontology/spatialrelations/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX admingeo: <http://data.ordnancesurvey.co.uk/ontology/admingeo/>
+      PREFIX : <http://id.ukpds.org/schema/>
 
-CONSTRUCT {
-    ?region skos:prefLabel ?name  .
-    ?region a admingeo:EuropeanRegion .
-    ?region admingeo:gssCode ?gssCode .
-    ?region :count ?count .
-}
-WHERE {
-    {
-        SELECT ?region (COUNT(?westminsterConstituency) AS ?count) WHERE 
+      CONSTRUCT {
+        ?region skos:prefLabel ?name  .
+        ?region a admingeo:EuropeanRegion .
+        ?region admingeo:gssCode ?gssCode .
+        ?region :count ?count .
+      }
+      WHERE {
         {
+          SELECT ?region (COUNT(?westminsterConstituency) AS ?count) WHERE
+          {
             ?region a admingeo:EuropeanRegion .
             ?region admingeo:gssCode ?gssCode .
             ?region admingeo:westminsterConstituency ?westminsterConstituency .
-        } GROUP BY ?region  
-    }
-    UNION
-    {
-        SELECT * WHERE {
+          } GROUP BY ?region
+        }
+        UNION
+        {
+          SELECT * WHERE {
             ?region skos:prefLabel ?name  .
             ?region a admingeo:EuropeanRegion .
             ?region admingeo:gssCode ?gssCode .
+          }
         }
+      }
+      ";
+      var externalQuery = new SparqlParameterizedString(externalQueryString);
+      return BaseController.ExecuteSingle(externalQuery, "http://data.ordnancesurvey.co.uk/datasets/os-linked-data/apis/sparql");
     }
-}
-";
-            var externalQuery = new SparqlParameterizedString(externalQueryString);
-            return BaseController.ExecuteSingle(externalQuery, "http://data.ordnancesurvey.co.uk/datasets/os-linked-data/apis/sparql");
-        }
 
-        [HttpGet]
-        public Graph region_constituencies(string region_code)
-        {
-            var queryString = @"
-PREFIX admingeo: <http://data.ordnancesurvey.co.uk/ontology/admingeo/>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX : <http://id.ukpds.org/schema/>
-
-CONSTRUCT {
-    ?region
-        a admingeo:EuropeanRegion ;
-        admingeo:gssCode ?regionCode ;
-        skos:prefLabel ?label .
-    ?constituency
-        a :ConstituencyGroup;
-        :constituencyGroupName ?constituencyName.
-}
-WHERE {
-    SERVICE <http://data.ordnancesurvey.co.uk/datasets/os-linked-data/apis/sparql> {
-        BIND (@regionCode AS ?regionCode)
+    [HttpGet]
+    public Graph region_by_id(string region_code)
+    {
+      var queryString = @"
+      PREFIX admingeo: <http://data.ordnancesurvey.co.uk/ontology/admingeo/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX : <http://id.ukpds.org/schema/>
+      CONSTRUCT {
         ?region
+          a admingeo:EuropeanRegion ;
+          admingeo:gssCode ?regionCode ;
+          skos:prefLabel ?label .
+        ?constituency
+          a :ConstituencyGroup;
+          :constituencyGroupName ?constituencyName.
+      }
+      WHERE {
+        SERVICE <http://data.ordnancesurvey.co.uk/datasets/os-linked-data/apis/sparql> {
+          BIND (@regionCode AS ?regionCode)
+          ?region
             a admingeo:EuropeanRegion ;
             admingeo:gssCode ?regionCode ;
             skos:prefLabel ?label ;
             admingeo:westminsterConstituency/admingeo:gssCode ?onsCode.
-    }
-    ?constituency
-        :onsCode ?onsCode;
-        :constituencyGroupName ?constituencyName.
-}";
-            var query = new SparqlParameterizedString(queryString);
-            query.SetLiteral("regionCode", region_code);
-            return BaseController.ExecuteSingle(query);
         }
+        ?constituency
+          :onsCode ?onsCode;
+          :constituencyGroupName ?constituencyName.
+      }";
+      var query = new SparqlParameterizedString(queryString);
+      query.SetLiteral("regionCode", region_code);
+      return BaseController.ExecuteSingle(query);
     }
+
+    [HttpGet]
+    public Graph region_constituencies(string region_code)
+    {
+      var queryString = @"
+      PREFIX admingeo: <http://data.ordnancesurvey.co.uk/ontology/admingeo/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX : <http://id.ukpds.org/schema/>
+
+      CONSTRUCT {
+        ?region
+          a admingeo:EuropeanRegion ;
+          admingeo:gssCode ?regionCode ;
+          skos:prefLabel ?regionName ;
+          :count ?count .
+        ?constituency
+          a :ConstituencyGroup;
+          :constituencyGroupName ?constituencyName ;
+          :constituencyGroupHasHouseSeat ?houseSeat .
+          ?seatIncumbency a :SeatIncumbency ;
+          :incumbencyHasMember ?member ;
+          :incumbencyEndDate ?seatIncumbencyEndDate ;
+          :incumbencyStartDate ?seatIncumbencyStartDate .
+        ?member
+          a :Person ;
+          :personGivenName ?givenName ;
+          :personFamilyName ?familyName ;
+          <http://example.com/F31CBD81AD8343898B49DC65743F0BDF> ?displayAs ;
+          :partyMemberHasPartyMembership ?partyMembership .
+        ?partyMembership
+          a :PartyMembership ;
+          :partyMembershipHasParty ?party .
+        ?party
+          a :Party ;
+          :partyName ?partyName .
+        _:x :value ?firstLetter .
+      }
+      WHERE {
+        {
+          SERVICE <http://data.ordnancesurvey.co.uk/datasets/os-linked-data/apis/sparql> {
+            SELECT ?region (COUNT(?constituency) AS ?count) WHERE {
+              BIND (@regionCode AS ?regionCode)
+              ?region
+                a admingeo:EuropeanRegion ;
+                admingeo:gssCode ?regionCode ;
+                admingeo:westminsterConstituency ?constituency .
+            } GROUP BY ?region
+          }
+
+          SERVICE <http://data.ordnancesurvey.co.uk/datasets/os-linked-data/apis/sparql> {
+            BIND (@regionCode AS ?regionCode)
+            ?region
+              a admingeo:EuropeanRegion ;
+              admingeo:gssCode ?regionCode ;
+              skos:prefLabel ?regionName ;
+              admingeo:westminsterConstituency/admingeo:gssCode ?onsCode.
+          }
+
+          ?constituency
+            :onsCode ?onsCode;
+            :constituencyGroupName ?constituencyName ;
+            :constituencyGroupHasHouseSeat ?houseSeat .
+          ?houseSeat :houseSeatHasSeatIncumbency ?seatIncumbency .
+          ?seatIncumbency a :SeatIncumbency ;
+          FILTER NOT EXISTS { ?seatIncumbency :incumbencyEndDate ?seatIncumbencyEndDate . }
+          OPTIONAL { ?seatIncumbency :incumbencyStartDate ?seatIncumbencyStartDate . }
+          OPTIONAL {
+            ?seatIncumbency :incumbencyHasMember ?member .
+            OPTIONAL { ?member :personGivenName ?givenName . }
+            OPTIONAL { ?member :personFamilyName ?familyName . }
+            OPTIONAL { ?member <http://example.com/F31CBD81AD8343898B49DC65743F0BDF> ?displayAs . }
+            OPTIONAL {
+              ?member :partyMemberHasPartyMembership ?partyMembership .
+              FILTER NOT EXISTS { ?partyMembership a :PastPartyMembership . }
+              OPTIONAL {
+                ?partyMembership :partyMembershipHasParty ?party .
+                OPTIONAL { ?party :partyName ?partyName . }
+              }
+            }
+          }
+        }
+
+        UNION {
+
+          SELECT DISTINCT ?firstLetter WHERE {
+            ?constituency
+              a :ConstituencyGroup ;
+              :onsCode ?onsCode;
+              :constituencyGroupName ?constituencyName .
+            BIND(ucase(SUBSTR(?constituencyName, 1, 1)) as ?firstLetter)
+          }
+        }
+      }";
+      var query = new SparqlParameterizedString(queryString);
+      query.SetLiteral("regionCode", region_code);
+      return BaseController.ExecuteSingle(query);
+    }
+
+    [HttpGet]
+    public Graph region_constituencies_a_to_z(string region_code)
+    {
+      var queryString = @"
+      PREFIX admingeo: <http://data.ordnancesurvey.co.uk/ontology/admingeo/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX : <http://id.ukpds.org/schema/>
+
+      CONSTRUCT {
+        ?region
+          a admingeo:EuropeanRegion ;
+          admingeo:gssCode ?regionCode ;
+          skos:prefLabel ?regionName .
+        _:x :value ?firstLetter .
+      }
+      WHERE {
+
+        SELECT * WHERE {
+
+          { SERVICE <http://data.ordnancesurvey.co.uk/datasets/os-linked-data/apis/sparql> {
+            BIND (@regionCode AS ?regionCode)
+            ?region
+              a admingeo:EuropeanRegion ;
+              admingeo:gssCode ?regionCode ;
+              skos:prefLabel ?regionName ;
+              admingeo:westminsterConstituency/admingeo:gssCode ?onsCode.
+          } }
+
+          UNION {
+            SELECT DISTINCT ?firstLetter WHERE {
+              ?constituency
+                a :ConstituencyGroup ;
+                :onsCode ?onsCode;
+                :constituencyGroupName ?constituencyName .
+              BIND(ucase(SUBSTR(?constituencyName, 1, 1)) as ?firstLetter)
+            }
+          }
+        }
+      }";
+      var query = new SparqlParameterizedString(queryString);
+      query.SetLiteral("regionCode", region_code);
+      return BaseController.ExecuteSingle(query);
+    }
+
+    [HttpGet]
+    public Graph region_constituencies_by_initial(string region_code)
+    {
+      var queryString = @"
+      PREFIX admingeo: <http://data.ordnancesurvey.co.uk/ontology/admingeo/>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX : <http://id.ukpds.org/schema/>
+
+      CONSTRUCT {
+        ?region
+          a admingeo:EuropeanRegion ;
+          admingeo:gssCode ?regionCode ;
+          skos:prefLabel ?regionName ;
+          :count ?count .
+        ?constituency
+          a :ConstituencyGroup;
+          :constituencyGroupName ?constituencyName ;
+          :constituencyGroupHasHouseSeat ?houseSeat .
+        ?seatIncumbency
+          a :SeatIncumbency ;
+          :incumbencyHasMember ?member ;
+          :incumbencyEndDate ?seatIncumbencyEndDate ;
+          :incumbencyStartDate ?seatIncumbencyStartDate .
+        ?member
+          a :Person ;
+          :personGivenName ?givenName ;
+          :personFamilyName ?familyName ;
+          <http://example.com/F31CBD81AD8343898B49DC65743F0BDF> ?displayAs ;
+          :partyMemberHasPartyMembership ?partyMembership .
+        ?partyMembership
+          a :PartyMembership ;
+          :partyMembershipHasParty ?party .
+        ?party
+          a :Party ;
+          :partyName ?partyName .
+        _:x :value ?firstLetter .
+      }
+      WHERE {
+        {
+          SERVICE <http://data.ordnancesurvey.co.uk/datasets/os-linked-data/apis/sparql> {
+            SELECT ?region (COUNT(?constituency) AS ?count) WHERE {
+              BIND (@regionCode AS ?regionCode)
+              ?region
+                a admingeo:EuropeanRegion ;
+                admingeo:gssCode ?regionCode ;
+                admingeo:westminsterConstituency ?constituency .
+            } GROUP BY ?region
+          }
+
+          SERVICE <http://data.ordnancesurvey.co.uk/datasets/os-linked-data/apis/sparql> {
+            BIND (@regionCode AS ?regionCode)
+            ?region
+              a admingeo:EuropeanRegion ;
+              admingeo:gssCode ?regionCode ;
+              skos:prefLabel ?regionName ;
+              admingeo:westminsterConstituency/admingeo:gssCode ?onsCode.
+          }
+
+          ?constituency
+            :onsCode ?onsCode;
+            :constituencyGroupName ?constituencyName ;
+            :constituencyGroupHasHouseSeat ?houseSeat .
+          ?houseSeat :houseSeatHasSeatIncumbency ?seatIncumbency .
+          ?seatIncumbency a :SeatIncumbency ;
+          FILTER NOT EXISTS { ?seatIncumbency :incumbencyEndDate ?seatIncumbencyEndDate . }
+          OPTIONAL { ?seatIncumbency :incumbencyStartDate ?seatIncumbencyStartDate . }
+          OPTIONAL {
+            ?seatIncumbency :incumbencyHasMember ?member .
+            OPTIONAL { ?member :personGivenName ?givenName . }
+            OPTIONAL { ?member :personFamilyName ?familyName . }
+            OPTIONAL { ?member <http://example.com/F31CBD81AD8343898B49DC65743F0BDF> ?displayAs . }
+            OPTIONAL {
+              ?member :partyMemberHasPartyMembership ?partyMembership .
+              FILTER NOT EXISTS { ?partyMembership a :PastPartyMembership . }
+              OPTIONAL {
+                ?partyMembership :partyMembershipHasParty ?party .
+                OPTIONAL { ?party :partyName ?partyName . }
+              }
+            }
+          }
+        }
+
+        UNION {
+
+          SELECT DISTINCT ?firstLetter WHERE {
+            ?constituency
+              a :ConstituencyGroup ;
+              :onsCode ?onsCode;
+              :constituencyGroupName ?constituencyName .
+            BIND(ucase(SUBSTR(?constituencyName, 1, 1)) as ?firstLetter)
+          }
+        }
+      }";
+      var query = new SparqlParameterizedString(queryString);
+      query.SetLiteral("regionCode", region_code);
+      return BaseController.ExecuteSingle(query);
+    }
+  }
 }

--- a/Parliament.Data.Api.FixedQuery/Controllers/HelpController.cs
+++ b/Parliament.Data.Api.FixedQuery/Controllers/HelpController.cs
@@ -54,6 +54,7 @@
                 this.Url.Route("WithoutExtension", new {action = "constituency_current_member", constituency_id = "dwtSdieB" }),
                 this.Url.Route("WithoutExtension", new {action = "constituency_contact_point", constituency_id = "dwtSdieB" }),
                 this.Url.Route("WithoutExtension", new {action = "constituency_lookup_by_postcode",postcode = "sw1p 3ja"}),
+                this.Url.Route("WithoutExtension", new {action = "find_your_constituency" }),
 
                 this.Url.Route("WithoutExtension", new {action = "party_index"}),
                 this.Url.Route("WithoutExtension", new {action = "party_by_id", party_id = "891w1b1k" }),
@@ -126,7 +127,10 @@
                 this.Url.Route("WithoutExtension", new {action = "image_by_id", image_id = "qnsCGpnw"}),
 
                 this.Url.Route("WithoutExtension", new {action = "region_index"}),
+                this.Url.Route("WithoutExtension", new {action = "region_by_id", region_code = "E15000001" })
                 this.Url.Route("WithoutExtension", new {action = "region_constituencies", region_code = "E15000001" })
+                this.Url.Route("WithoutExtension", new {action = "region_constituencies_a_to_z", region_code = "E15000001" })
+                this.Url.Route("WithoutExtension", new {action = "region_constituencies_by_initial", region_code = "E15000001" })
             } as IEnumerable<string>;
 
             // Make links relative, remove application virtual path (in this case, a trailing forward slash).

--- a/Parliament.Data.Api.FixedQueryTests/ConstituencySparql.cs
+++ b/Parliament.Data.Api.FixedQueryTests/ConstituencySparql.cs
@@ -100,5 +100,11 @@
         {
             ValidateSparql(() => controller.constituency_lookup_by_postcode(string.Empty));
         }
+
+        [TestMethod()]
+        public void FindYourConstituency()
+        {
+            ValidateSparql(() => controller.find_your_constituency());
+        }
     }
 }

--- a/Parliament.Data.Api.FixedQueryTests/RegionSparql.cs
+++ b/Parliament.Data.Api.FixedQueryTests/RegionSparql.cs
@@ -24,9 +24,27 @@
         }
 
         [TestMethod()]
+        public void RegionByIdSparql()
+        {
+          ValidateSparql(() => controller.region_by_id(string.Empty));
+        }
+
+        [TestMethod()]
         public void RegionConstituenciesSparql()
         {
             ValidateSparql(() => controller.region_constituencies(string.Empty));
+        }
+
+        [TestMethod()]
+        public void RegionConstituenciesAtoZSparql()
+        {
+            ValidateSparql(() => controller.region_constituencies_a_to_z(string.Empty));
+        }
+
+        [TestMethod()]
+        public void RegionConstituenciesByInitialSparql()
+        {
+            ValidateSparql(() => controller.region_constituencies_by_initial(string.Empty));
         }
     }
 }


### PR DESCRIPTION
Add queries for places/constituencies
1. Add queries to RegionsController
- region_constituencies
- region_constituencies_a_to_z
- region_constituencies_by_initial

2. Rename queries in Regions Controller
- renamed region_constituencies to region_by_id

3. Add query to ConstituenciesController
- find_your_constituency

4. Add tests for all new routes above
5. Add examples of use for all new routes in HelpController