### PR TITLE
query showing current members including exofficio alternate and layme…

### DIFF
--- a/Parliament.Data.Api.FixedQuery/Sparql/group_current_membership
+++ b/Parliament.Data.Api.FixedQuery/Sparql/group_current_membership
@@ -1,0 +1,174 @@
+PREFIX : @schemaUri
+
+CONSTRUCT{
+?group
+     a :Group ;
+     :groupName ?groupName ;
+     :groupStartDate ?groupStartDate ;
+     :groupEndDate ?groupEndDate ;
+     :formalBodyRemit ?bodyRemit;
+     :formalBodyHasFormalBodyChair ?bodyChair ;
+     :formalBodyHasLeadHouse ?leadHouse;
+     :formalBodyHasFormalBodyMembership ?bodyMembership ;
+     :formalBodyName ?formalBodyName ;
+     :formalBodyStartDate ?formalbodystartDate ;
+     :formalBodyHasHouse ?house ;
+     :formalBodyHasFormalBodyType ?formalbodytype .
+
+?bodyMembership
+    a :FormalBodyMembership ;
+    :memberHasExOfficioMembership ?hasExofficio ;
+    :memberHasAlternateMembership ?hasAlternate ;
+    :formalBodyMembershipHasFormalBody ?formalBody ;
+    :formalBodyMembershipHasPerson ?person .
+
+?formalBody
+    a :FormalBody .
+     
+?bodyChair
+    a :Position ;
+    :positionHasIncumbency ?incum .
+     
+?incumbency
+     a :Incumbency ;
+     :incumbencyStartDate ?sd ;
+     :incumbencyHasPerson ?person .
+     
+?formalbodytype
+     a :FormalBodyType ;
+     :formalbodyTypeName ?cmteetype .
+     
+?house
+     a :House ;
+     :houseName ?houseName .
+     
+?person
+     a :Person ;
+     :partyMemberHasPartyMembership ?partyMembership ;
+     :personHasFormalBodyMembership ?bodyMembership ;
+     :memberHasParliamentaryIncumbency ?parlIncumbency ;
+     :formalBodyLayPersonMnisId ?layPersonid ;
+     :memberHasMemberImage ?image ;
+     <http://example.com/F31CBD81AD8343898B49DC65743F0BDF> ?displayAs .
+	 
+?parlIncumbency
+     a :ParliamentIncumbency ;
+     :seatIncumbencyHasHouseSeat ?houseSeat .
+     
+?houseSeat
+     a :HouseSeat ;
+     :houseSeatHasConstituencyGroup ?constituencyGroup .
+     
+?constituencyGroup 
+     a :ConstituencyGroup ;
+     :constituencyGroupName ?constituencyGroupName .
+	 
+?partyMembership
+     a :PartyMembership ;
+     :partyMembershipHasParty ?party .
+     
+?party
+     a :Party ;
+     :partyName ?partyName .
+
+?image
+     a :MemberImage .
+
+}
+WHERE {
+     { 
+     SELECT * WHERE {
+     BIND(@group_id AS ?group)
+     OPTIONAL {?group :formalBodyHasLeadHouse ?leadHouse } .
+     BIND (?leadHouse AS ?house) .
+
+     ?group :formalBodyHasFormalBodyMembership ?bodyMembership .
+
+     MINUS {?group :groupEndDate ?groupEndDate } .
+     MINUS {?group :formalBodyEndDate  ?formalbodyEndDate } .
+
+     OPTIONAL {?group :formalBodyRemit ?bodyRemit } . 
+
+     ?bodyMembership :formalBodyMembershipHasPerson ?person .
+
+     OPTIONAL            {
+     ?bodyMembership :memberHasExOfficioMembership ?hasExofficio .
+     ?bodyMembership :memberHasAlternateMembership ?hasAlternate .
+                          }
+ 
+     MINUS {?bodyMembership :formalBodyMembershipEndDate ?membershipEndDate } . 
+
+     OPTIONAL            {
+        ?group :formalBodyHasFormalBodyChair ?bodyChair  .
+
+        ?bodyChair :positionHasIncumbency ?incumbency .
+  
+        ?incumbency 
+            :incumbencyStartDate ?sd ;
+            :incumbencyHasPerson ?person .
+    
+     MINUS {?incumbency :incumbencyEndDate ?ed}  .
+
+     OPTIONAL             {
+     ?person :personHasFormalBodyMembership ?bodyMembership .
+     ?person :memberHasParliamentaryIncumbency ?parlIncumbency .
+                           }
+
+     MINUS {?parlIncumbency :parliamentaryIncumbencyEndDate ?incumbencyEndDate }  .	
+     ?bodyMembership :formalBodyMembershipHasFormalBody ?formalBody .
+     ?formalBody a :FormalBody .	
+
+     MINUS {?bodyMembership :formalBodyMembershipEndDate ?membershipEndDate } .
+                           }
+
+
+     OPTIONAL              {
+     ?person :personHasFormalBodyMembership ?bodyMembership .
+     ?person :memberHasParliamentaryIncumbency ?parlIncumbency .
+                           }
+   
+     MINUS {?bodyMembership :formalBodyMembershipEndDate ?membershipEndDate } .  
+
+     OPTIONAL              {
+     ?parlIncumbency :seatIncumbencyHasHouseSeat ?houseSeat .
+     ?houseSeat :houseSeatHasConstituencyGroup ?constituencyGroup .
+     ?constituencyGroup :constituencyGroupName ?constituencyGroupName .
+                            }
+
+     MINUS {?parlIncumbency :parliamentaryIncumbencyEndDate ?incumbencyEndDate}  .
+     MINUS {?constituencyGroup :constituencyGroupEndDate ?constituencyGroupEnd } . 
+
+     ?person 
+        :personFamilyName ?familyName ;
+        :personGivenName ?givenName ;
+        <http://example.com/F31CBD81AD8343898B49DC65743F0BDF> ?displayAs ;
+        <http://example.com/A5EE13ABE03C4D3A8F1A274F57097B6C> ?listAs .
+
+    OPTIONAL {?person :formalBodyLayPersonMnisId ?layPersonid } .
+
+    OPTIONAL              {
+    ?person :memberHasMemberImage ?image .
+    ?image a :MemberImage .
+                           }  
+
+    OPTIONAL              {
+    ?person :partyMemberHasPartyMembership ?partyMembership .
+    ?partyMembership :partyMembershipHasParty ?party .
+    ?party :partyName ?partyName .
+                           }
+
+    MINUS {?partyMembership :partyMembershipEndDate ?partyMembershipEndDate } .           
+   
+    ?group 
+        :formalBodyName ?formalBodyName ;
+        :formalBodyHasFormalBodyType ?formalbodytype ;
+        :formalBodyHasHouse ?house .
+   
+    ?house :houseName ?houseName .
+
+    ?formalbodytype :formalBodyTypeName ?cmteetype .  
+    }
+ }  
+ 
+} ORDER BY DESC(?bodyChair) ASC(?familyName)
+

--- a/Parliament.Data.Api.FixedQuery/Sparql/group_current_membership.sparql
+++ b/Parliament.Data.Api.FixedQuery/Sparql/group_current_membership.sparql
@@ -1,0 +1,174 @@
+PREFIX : @schemaUri
+
+CONSTRUCT{
+?group
+     a :Group ;
+     :groupName ?groupName ;
+     :groupStartDate ?groupStartDate ;
+     :groupEndDate ?groupEndDate ;
+     :formalBodyRemit ?bodyRemit;
+     :formalBodyHasFormalBodyChair ?bodyChair ;
+     :formalBodyHasLeadHouse ?leadHouse;
+     :formalBodyHasFormalBodyMembership ?bodyMembership ;
+     :formalBodyName ?formalBodyName ;
+     :formalBodyStartDate ?formalbodystartDate ;
+     :formalBodyHasHouse ?house ;
+     :formalBodyHasFormalBodyType ?formalbodytype .
+
+?bodyMembership
+    a :FormalBodyMembership ;
+    :memberHasExOfficioMembership ?hasExofficio ;
+    :memberHasAlternateMembership ?hasAlternate ;
+    :formalBodyMembershipHasFormalBody ?formalBody ;
+    :formalBodyMembershipHasPerson ?person .
+
+?formalBody
+    a :FormalBody .
+     
+?bodyChair
+    a :Position ;
+    :positionHasIncumbency ?incum .
+     
+?incumbency
+     a :Incumbency ;
+     :incumbencyStartDate ?sd ;
+     :incumbencyHasPerson ?person .
+     
+?formalbodytype
+     a :FormalBodyType ;
+     :formalbodyTypeName ?cmteetype .
+     
+?house
+     a :House ;
+     :houseName ?houseName .
+     
+?person
+     a :Person ;
+     :partyMemberHasPartyMembership ?partyMembership ;
+     :personHasFormalBodyMembership ?bodyMembership ;
+     :memberHasParliamentaryIncumbency ?parlIncumbency ;
+     :formalBodyLayPersonMnisId ?layPersonid ;
+     :memberHasMemberImage ?image ;
+     <http://example.com/F31CBD81AD8343898B49DC65743F0BDF> ?displayAs .
+	 
+?parlIncumbency
+     a :ParliamentIncumbency ;
+     :seatIncumbencyHasHouseSeat ?houseSeat .
+     
+?houseSeat
+     a :HouseSeat ;
+     :houseSeatHasConstituencyGroup ?constituencyGroup .
+     
+?constituencyGroup 
+     a :ConstituencyGroup ;
+     :constituencyGroupName ?constituencyGroupName .
+	 
+?partyMembership
+     a :PartyMembership ;
+     :partyMembershipHasParty ?party .
+     
+?party
+     a :Party ;
+     :partyName ?partyName .
+
+?image
+     a :MemberImage .
+
+}
+WHERE {
+     { 
+     SELECT * WHERE {
+     BIND(@group_id AS ?group)
+     OPTIONAL {?group :formalBodyHasLeadHouse ?leadHouse } .
+     BIND (?leadHouse AS ?house) .
+
+     ?group :formalBodyHasFormalBodyMembership ?bodyMembership .
+
+     MINUS {?group :groupEndDate ?groupEndDate } .
+     MINUS {?group :formalBodyEndDate  ?formalbodyEndDate } .
+
+     OPTIONAL {?group :formalBodyRemit ?bodyRemit } . 
+
+     ?bodyMembership :formalBodyMembershipHasPerson ?person .
+
+     OPTIONAL            {
+     ?bodyMembership :memberHasExOfficioMembership ?hasExofficio .
+     ?bodyMembership :memberHasAlternateMembership ?hasAlternate .
+                          }
+ 
+     MINUS {?bodyMembership :formalBodyMembershipEndDate ?membershipEndDate } . 
+
+     OPTIONAL            {
+        ?group :formalBodyHasFormalBodyChair ?bodyChair  .
+
+        ?bodyChair :positionHasIncumbency ?incumbency .
+  
+        ?incumbency 
+            :incumbencyStartDate ?sd ;
+            :incumbencyHasPerson ?person .
+    
+     MINUS {?incumbency :incumbencyEndDate ?ed}  .
+
+     OPTIONAL             {
+     ?person :personHasFormalBodyMembership ?bodyMembership .
+     ?person :memberHasParliamentaryIncumbency ?parlIncumbency .
+                           }
+
+     MINUS {?parlIncumbency :parliamentaryIncumbencyEndDate ?incumbencyEndDate }  .	
+     ?bodyMembership :formalBodyMembershipHasFormalBody ?formalBody .
+     ?formalBody a :FormalBody .	
+
+     MINUS {?bodyMembership :formalBodyMembershipEndDate ?membershipEndDate } .
+                           }
+
+
+     OPTIONAL              {
+     ?person :personHasFormalBodyMembership ?bodyMembership .
+     ?person :memberHasParliamentaryIncumbency ?parlIncumbency .
+                           }
+   
+     MINUS {?bodyMembership :formalBodyMembershipEndDate ?membershipEndDate } .  
+
+     OPTIONAL              {
+     ?parlIncumbency :seatIncumbencyHasHouseSeat ?houseSeat .
+     ?houseSeat :houseSeatHasConstituencyGroup ?constituencyGroup .
+     ?constituencyGroup :constituencyGroupName ?constituencyGroupName .
+                            }
+
+     MINUS {?parlIncumbency :parliamentaryIncumbencyEndDate ?incumbencyEndDate}  .
+     MINUS {?constituencyGroup :constituencyGroupEndDate ?constituencyGroupEnd } . 
+
+     ?person 
+        :personFamilyName ?familyName ;
+        :personGivenName ?givenName ;
+        <http://example.com/F31CBD81AD8343898B49DC65743F0BDF> ?displayAs ;
+        <http://example.com/A5EE13ABE03C4D3A8F1A274F57097B6C> ?listAs .
+
+    OPTIONAL {?person :formalBodyLayPersonMnisId ?layPersonid } .
+
+    OPTIONAL              {
+    ?person :memberHasMemberImage ?image .
+    ?image a :MemberImage .
+                           }  
+
+    OPTIONAL              {
+    ?person :partyMemberHasPartyMembership ?partyMembership .
+    ?partyMembership :partyMembershipHasParty ?party .
+    ?party :partyName ?partyName .
+                           }
+
+    MINUS {?partyMembership :partyMembershipEndDate ?partyMembershipEndDate } .           
+   
+    ?group 
+        :formalBodyName ?formalBodyName ;
+        :formalBodyHasFormalBodyType ?formalbodytype ;
+        :formalBodyHasHouse ?house .
+   
+    ?house :houseName ?houseName .
+
+    ?formalbodytype :formalBodyTypeName ?cmteetype .  
+    }
+ }  
+ 
+} ORDER BY DESC(?bodyChair) ASC(?familyName)
+


### PR DESCRIPTION
…mbers